### PR TITLE
Add standard help options

### DIFF
--- a/src/main/java/dev/grevend/count/Count.java
+++ b/src/main/java/dev/grevend/count/Count.java
@@ -11,7 +11,7 @@ import static picocli.CommandLine.Command;
  *
  * @since sprint 1
  */
-@Command(name = "count", version = "count 1.0",
+@Command(name = "count", version = "count 1.0", mixinStandardHelpOptions = true,
     description = "Count the human-readable characters, lines, or words from stdin or a file and write the number to stdout or a file.")
 public class Count implements Callable<Integer> {
 


### PR DESCRIPTION
# Description

Add mixinStandardHelpOptions parameter to command annotation.

## Checklist

### Management

- [x] Link Issue
- [x] Add Description
- [x] Assign Sprint
- [x] Assign Moscow Prioritization

### Implementation

- [x] Documentation
- [x] Possible Optimizations
- [x] Convention Usage

### Review

- [x] Complexity & Readability
- [x] Convention Usage
- [x] Formatting
