### PR TITLE
Add text input from stdin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,12 @@
             <version>3.11.1</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>3.8.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -36,12 +36,6 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>3.0.0-M4</version>
-                <configuration>
-                    <argLine>--add-exports
-                        org.junit.platform.commons/org.junit.platform.commons.util=ALL-UNNAMED --add-exports
-                        org.junit.platform.commons/org.junit.platform.commons.logging=ALL-UNNAMED
-                    </argLine>
-                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/src/main/java/dev/grevend/count/Count.java
+++ b/src/main/java/dev/grevend/count/Count.java
@@ -1,8 +1,11 @@
 package dev.grevend.count;
 
 import picocli.CommandLine;
+import picocli.CommandLine.Model.CommandSpec;
+import picocli.CommandLine.Spec;
 
 import java.io.InputStream;
+import java.io.PrintWriter;
 import java.util.concurrent.Callable;
 
 import static picocli.CommandLine.Command;
@@ -15,6 +18,9 @@ import static picocli.CommandLine.Command;
 @Command(name = "count", version = "count 1.0", mixinStandardHelpOptions = true,
     description = "Count the human-readable characters, lines, or words from stdin or a file and write the number to stdout or a file.")
 public class Count implements Callable<Integer> {
+
+    @Spec
+    private CommandSpec spec;
 
     /**
      * Main program entry point. Creates a command line instance and delegates the given program args to the count command.
@@ -41,6 +47,17 @@ public class Count implements Callable<Integer> {
      */
     private InputStream in() {
         return System.in;
+    }
+
+    /**
+     * Returns or constructs an output stream based on the selected command options.
+     *
+     * @return the output stream
+     *
+     * @since sprint 1
+     */
+    private PrintWriter out() {
+        return spec.commandLine().getOut();
     }
 
 }

--- a/src/main/java/dev/grevend/count/Count.java
+++ b/src/main/java/dev/grevend/count/Count.java
@@ -4,8 +4,7 @@ import picocli.CommandLine;
 import picocli.CommandLine.Model.CommandSpec;
 import picocli.CommandLine.Spec;
 
-import java.io.InputStream;
-import java.io.PrintWriter;
+import java.io.*;
 import java.util.concurrent.Callable;
 
 import static picocli.CommandLine.Command;
@@ -33,8 +32,21 @@ public class Count implements Callable<Integer> {
         System.exit(new CommandLine(new Count()).execute(args));
     }
 
+    /**
+     * Reads text from the selected input stream, computes the character count, and prints the value into the specified output stream.
+     *
+     * @return the command exit code
+     *
+     * @throws IOException if the input or output stream cannot be closed
+     * @since sprint 1
+     */
     @Override
-    public Integer call() {
+    public Integer call() throws IOException {
+        try (var reader = new BufferedReader(new InputStreamReader(in())); var out = out()) {
+            for (String line = reader.readLine(); line != null && !line.isEmpty(); line = reader.readLine()) {
+                out.println(line);
+            }
+        }
         return 0;
     }
 

--- a/src/main/java/dev/grevend/count/Count.java
+++ b/src/main/java/dev/grevend/count/Count.java
@@ -2,6 +2,7 @@ package dev.grevend.count;
 
 import picocli.CommandLine;
 
+import java.io.InputStream;
 import java.util.concurrent.Callable;
 
 import static picocli.CommandLine.Command;
@@ -29,6 +30,17 @@ public class Count implements Callable<Integer> {
     @Override
     public Integer call() {
         return 0;
+    }
+
+    /**
+     * Returns or constructs an input stream based on the selected command options.
+     *
+     * @return the input stream
+     *
+     * @since sprint 1
+     */
+    private InputStream in() {
+        return System.in;
     }
 
 }

--- a/src/main/java/dev/grevend/count/Count.java
+++ b/src/main/java/dev/grevend/count/Count.java
@@ -4,7 +4,10 @@ import picocli.CommandLine;
 import picocli.CommandLine.Model.CommandSpec;
 import picocli.CommandLine.Spec;
 
-import java.io.*;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.PrintWriter;
 import java.util.concurrent.Callable;
 
 import static picocli.CommandLine.Command;
@@ -42,8 +45,8 @@ public class Count implements Callable<Integer> {
      */
     @Override
     public Integer call() throws IOException {
-        try (var reader = new BufferedReader(new InputStreamReader(in())); var out = out()) {
-            for (String line = reader.readLine(); line != null && !line.isEmpty(); line = reader.readLine()) {
+        try (var reader = in(); var out = out()) {
+            for (String line = reader.readLine(); line != null && !line.isBlank(); line = reader.readLine()) {
                 out.println(line);
             }
         }
@@ -57,8 +60,8 @@ public class Count implements Callable<Integer> {
      *
      * @since sprint 1
      */
-    private InputStream in() {
-        return System.in;
+    protected BufferedReader in() {
+        return new BufferedReader(new InputStreamReader(System.in));
     }
 
     /**

--- a/src/test/java/dev/grevend/count/CountTest.java
+++ b/src/test/java/dev/grevend/count/CountTest.java
@@ -2,14 +2,20 @@ package dev.grevend.count;
 
 import org.junit.jupiter.api.Test;
 
-import java.io.IOException;
-
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class CountTest {
 
     @Test
-    public void testStdin() throws IOException {
+    public void testHelp() {
+        var commandLine = new TestCommandLine("-h");
+        assertThat(commandLine.execute()).isZero();
+        assertThat(commandLine.out().toString()).contains("Count the human-readable characters, lines, or" +
+            " words from stdin or a file and" + System.lineSeparator() + "write the number to stdout or a file.");
+    }
+
+    @Test
+    public void testStdin() {
         var commandLine = new TestCommandLine(new String[]{}, new String[]{"test"});
         assertThat(commandLine.execute()).isZero();
         assertThat(commandLine.out().toString()).isEqualTo("test" + System.lineSeparator());

--- a/src/test/java/dev/grevend/count/CountTest.java
+++ b/src/test/java/dev/grevend/count/CountTest.java
@@ -1,0 +1,18 @@
+package dev.grevend.count;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class CountTest {
+
+    @Test
+    public void testStdin() throws IOException {
+        var commandLine = new TestCommandLine(new String[]{}, new String[]{"test"});
+        assertThat(commandLine.execute()).isZero();
+        assertThat(commandLine.out().toString()).isEqualTo("test" + System.lineSeparator());
+    }
+
+}

--- a/src/test/java/dev/grevend/count/TestCommandLine.java
+++ b/src/test/java/dev/grevend/count/TestCommandLine.java
@@ -1,9 +1,14 @@
 package dev.grevend.count;
 
+import org.assertj.core.util.Arrays;
 import picocli.CommandLine;
 
+import java.io.BufferedReader;
+import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
+
+import static org.mockito.Mockito.*;
 
 /**
  * A testable CommandLine object.
@@ -27,7 +32,29 @@ public class TestCommandLine {
         this.args = args;
         this.commandLine = new CommandLine(new Count());
         this.out = new StringWriter();
-        this.commandLine.setOut(new PrintWriter(out));
+        this.commandLine.setOut(new PrintWriter(this.out));
+    }
+
+    /**
+     * Constructs a test CommandLine with the provided args and a mocked input stream.
+     *
+     * @param args  the test command args
+     * @param input the test command input
+     *
+     * @since sprint 1
+     */
+    protected TestCommandLine(String[] args, String[] input) {
+        this.args = args;
+        var reader = mock(BufferedReader.class);
+        var countSpy = spy(new Count());
+        when(countSpy.in()).thenReturn(reader);
+        var iter = Arrays.asList(input).iterator();
+        try {
+            when(reader.readLine()).thenAnswer(invocation -> iter.hasNext() ? iter.next() : null);
+        } catch (IOException ignored) {}
+        this.commandLine = new CommandLine(countSpy);
+        this.out = new StringWriter();
+        this.commandLine.setOut(new PrintWriter(this.out));
     }
 
     /**

--- a/src/test/java/dev/grevend/count/TestCommandLine.java
+++ b/src/test/java/dev/grevend/count/TestCommandLine.java
@@ -1,0 +1,78 @@
+package dev.grevend.count;
+
+import picocli.CommandLine;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+
+/**
+ * A testable CommandLine object.
+ *
+ * @since sprint 1
+ */
+public class TestCommandLine {
+
+    private final String[] args;
+    private final CommandLine commandLine;
+    private final StringWriter out;
+
+    /**
+     * Constructs a test CommandLine with the provided args.
+     *
+     * @param args the test command args
+     *
+     * @since sprint 1
+     */
+    protected TestCommandLine(String[] args) {
+        this.args = args;
+        this.commandLine = new CommandLine(new Count());
+        this.out = new StringWriter();
+        this.commandLine.setOut(new PrintWriter(out));
+    }
+
+    /**
+     * Executes the count command with the stored test args.
+     *
+     * @return the resulting exit code
+     *
+     * @since sprint 1
+     */
+    public int execute() {
+        return commandLine.execute(args);
+    }
+
+    /**
+     * Returns the constructed StringWriter representing the test output stream.
+     *
+     * @return the output stream as a StringWriter
+     *
+     * @since sprint 1
+     */
+    public StringWriter out() {
+        return out;
+    }
+
+    /**
+     * Returns the test CommandLine object.
+     *
+     * @return the test CommandLine
+     *
+     * @since sprint 1
+     */
+    public CommandLine commandLine() {
+        return commandLine;
+    }
+
+    /**
+     * Returns a joined version of the test args.
+     *
+     * @return the test display name / args
+     *
+     * @since sprint 1
+     */
+    @Override
+    public String toString() {
+        return String.join(" ", args);
+    }
+
+}

--- a/src/test/java/dev/grevend/count/TestCommandLine.java
+++ b/src/test/java/dev/grevend/count/TestCommandLine.java
@@ -28,7 +28,7 @@ public class TestCommandLine {
      *
      * @since sprint 1
      */
-    protected TestCommandLine(String[] args) {
+    protected TestCommandLine(String... args) {
         this.args = args;
         this.commandLine = new CommandLine(new Count());
         this.out = new StringWriter();


### PR DESCRIPTION
# Description

- Allow the command to read text from stdin by default.
- Add basic stdin CommandLine testing.

## Checklist

### Management

- [x] Link Issue
- [x] Add Description
- [x] Assign Sprint
- [x] Assign Moscow Prioritization

### Testing

- [x] Functionality
- [x] Coverage >= 80%

### Implementation

- [x] Documentation
- [x] Possible Optimizations
- [x] Convention Usage

### Review

- [x] Complexity & Readability
- [x] Convention Usage
- [x] Formatting
