### PR TITLE
Convert counting method into an option

### DIFF
--- a/src/main/java/dev/grevend/count/Count.java
+++ b/src/main/java/dev/grevend/count/Count.java
@@ -42,7 +42,7 @@ public class Count implements Callable<Integer> {
     }
 
     /**
-     * Reads text from the selected input stream, computes the character count, and prints the value into the specified output stream.
+     * Reads text from the selected input stream, computes a count using the method option, and prints the value into the specified output stream.
      *
      * @return the command exit code
      *

--- a/src/main/java/dev/grevend/count/Count.java
+++ b/src/main/java/dev/grevend/count/Count.java
@@ -2,6 +2,7 @@ package dev.grevend.count;
 
 import picocli.CommandLine;
 import picocli.CommandLine.Model.CommandSpec;
+import picocli.CommandLine.Option;
 import picocli.CommandLine.Spec;
 
 import java.io.BufferedReader;
@@ -28,6 +29,10 @@ public class Count implements Callable<Integer> {
 
     @Spec
     private CommandSpec spec;
+
+    @Option(names = {"-m", "--method"}, description = "Counting method (default: chars)", arity = "0..1",
+        defaultValue = "chars", showDefaultValue = CommandLine.Help.Visibility.NEVER)
+    private CountingMethods method;
 
     /**
      * Main program entry point. Creates a command line instance and delegates the given program args to the count command.

--- a/src/main/java/dev/grevend/count/Count.java
+++ b/src/main/java/dev/grevend/count/Count.java
@@ -12,7 +12,6 @@ import java.io.PrintWriter;
 import java.util.Objects;
 import java.util.concurrent.Callable;
 import java.util.regex.MatchResult;
-import java.util.regex.Pattern;
 
 import static picocli.CommandLine.Command;
 
@@ -24,8 +23,6 @@ import static picocli.CommandLine.Command;
 @Command(name = "count", version = "count 1.0", mixinStandardHelpOptions = true,
     description = "Count the human-readable characters, lines, or words from stdin or a file and write the number to stdout or a file.")
 public class Count implements Callable<Integer> {
-
-    private final Pattern humanReadable = Pattern.compile("[^\\p{C}\\p{Z}]+", Pattern.UNICODE_CHARACTER_CLASS);
 
     @Spec
     private CommandSpec spec;
@@ -56,13 +53,7 @@ public class Count implements Callable<Integer> {
     @Override
     public Integer call() throws IOException {
         try (var reader = in(); var writer = out()) {
-            writer.println(reader.lines()
-                .filter(Objects::nonNull)
-                .flatMapToInt(line -> humanReadable.matcher(line.strip())
-                    .results()
-                    .map(MatchResult::group)
-                    .mapToInt(String::length))
-                .reduce(0, Integer::sum));
+            writer.println(reader.lines().filter(Objects::nonNull).flatMapToInt(method).reduce(0, Integer::sum));
         }
         return 0;
     }

--- a/src/main/java/dev/grevend/count/Count.java
+++ b/src/main/java/dev/grevend/count/Count.java
@@ -11,7 +11,6 @@ import java.io.InputStreamReader;
 import java.io.PrintWriter;
 import java.util.Objects;
 import java.util.concurrent.Callable;
-import java.util.regex.MatchResult;
 
 import static picocli.CommandLine.Command;
 

--- a/src/main/java/dev/grevend/count/CountingMethods.java
+++ b/src/main/java/dev/grevend/count/CountingMethods.java
@@ -1,0 +1,5 @@
+package dev.grevend.count;
+
+public enum CountingMethods {
+    chars, words, lines
+}

--- a/src/main/java/dev/grevend/count/CountingMethods.java
+++ b/src/main/java/dev/grevend/count/CountingMethods.java
@@ -1,32 +1,40 @@
 package dev.grevend.count;
 
-import java.util.function.ToIntFunction;
+import java.util.function.Function;
+import java.util.regex.MatchResult;
+import java.util.regex.Pattern;
+import java.util.stream.IntStream;
 
-public enum CountingMethods implements ToIntFunction<String> {
+public enum CountingMethods implements Function<String, IntStream> {
 
     chars() {
 
         @Override
-        public int applyAsInt(String line) {
-            return 0;
+        public IntStream apply(String line) {
+            return humanReadable.matcher(line.strip())
+                .results()
+                .map(MatchResult::group)
+                .mapToInt(String::length);
         }
 
     },
     words() {
 
         @Override
-        public int applyAsInt(String value) {
-            return 0;
+        public IntStream apply(String line) {
+            return IntStream.empty();
         }
 
     },
     lines() {
-        
+
         @Override
-        public int applyAsInt(String value) {
-            return 0;
+        public IntStream apply(String line) {
+            return IntStream.empty();
         }
 
-    }
+    };
+
+    private static final Pattern humanReadable = Pattern.compile("[^\\p{C}\\p{Z}]+", Pattern.UNICODE_CHARACTER_CLASS);
 
 }

--- a/src/main/java/dev/grevend/count/CountingMethods.java
+++ b/src/main/java/dev/grevend/count/CountingMethods.java
@@ -1,5 +1,32 @@
 package dev.grevend.count;
 
-public enum CountingMethods {
-    chars, words, lines
+import java.util.function.ToIntFunction;
+
+public enum CountingMethods implements ToIntFunction<String> {
+
+    chars() {
+
+        @Override
+        public int applyAsInt(String line) {
+            return 0;
+        }
+
+    },
+    words() {
+
+        @Override
+        public int applyAsInt(String value) {
+            return 0;
+        }
+
+    },
+    lines() {
+        
+        @Override
+        public int applyAsInt(String value) {
+            return 0;
+        }
+
+    }
+
 }

--- a/src/main/java/dev/grevend/count/CountingMethods.java
+++ b/src/main/java/dev/grevend/count/CountingMethods.java
@@ -9,24 +9,26 @@ public enum CountingMethods implements Function<String, IntStream> {
 
     chars() {
 
+        /**
+         * Computes the character counts / lengths of all matched groups based on the humanReadable pattern.
+         *
+         * @param line the current text chunk
+         * @return an int stream of counts
+         * @since sprint 1
+         */
         @Override
         public IntStream apply(String line) {
-            return humanReadable.matcher(line.strip())
-                .results()
-                .map(MatchResult::group)
-                .mapToInt(String::length);
+            return humanReadable.matcher(line.strip()).results().map(MatchResult::group).mapToInt(String::length);
         }
 
-    },
-    words() {
+    }, words() {
 
         @Override
         public IntStream apply(String line) {
             return IntStream.empty();
         }
 
-    },
-    lines() {
+    }, lines() {
 
         @Override
         public IntStream apply(String line) {

--- a/src/test/java/dev/grevend/count/TestCommandLine.java
+++ b/src/test/java/dev/grevend/count/TestCommandLine.java
@@ -1,12 +1,11 @@
 package dev.grevend.count;
 
-import org.assertj.core.util.Arrays;
 import picocli.CommandLine;
 
 import java.io.BufferedReader;
-import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.util.stream.Stream;
 
 import static org.mockito.Mockito.*;
 
@@ -48,10 +47,7 @@ public final class TestCommandLine {
         var reader = mock(BufferedReader.class);
         var countSpy = spy(new Count());
         when(countSpy.in()).thenReturn(reader);
-        var iter = Arrays.asList(input).iterator();
-        try {
-            when(reader.readLine()).thenAnswer(invocation -> iter.hasNext() ? iter.next() : null);
-        } catch (IOException ignored) {}
+        when(reader.lines()).thenReturn(Stream.of(input));
         this.commandLine = new CommandLine(countSpy);
         this.out = new StringWriter();
         this.commandLine.setOut(new PrintWriter(this.out));


### PR DESCRIPTION
# Description

Add method option to the command to allow future expansion of counting methods.

## Checklist

### Management

- [x] Link Issue
- [x] Add Description
- [x] Assign Sprint
- [x] Assign Moscow Prioritization

### Testing

- [x] Functionality
- [x] Coverage >= 80%

### Implementation

- [x] Documentation
- [x] Possible Optimizations
- [x] Convention Usage

### Review

- [x] Complexity & Readability
- [x] Convention Usage
- [x] Formatting
- [x] Possible Optimizations
