### PR TITLE
Add number of lines count method

### DIFF
--- a/src/main/java/dev/grevend/count/Count.java
+++ b/src/main/java/dev/grevend/count/Count.java
@@ -52,7 +52,8 @@ public class Count implements Callable<Integer> {
     @Override
     public Integer call() throws IOException {
         try (var reader = in(); var writer = out()) {
-            writer.println(reader.lines().filter(Objects::nonNull).flatMapToInt(method).reduce(0, Integer::sum));
+            writer.println(reader.lines().filter(Objects::nonNull).map(String::strip)
+                .flatMapToInt(method).reduce(0, Integer::sum));
         }
         return 0;
     }

--- a/src/main/java/dev/grevend/count/CountingMethods.java
+++ b/src/main/java/dev/grevend/count/CountingMethods.java
@@ -14,6 +14,7 @@ public enum CountingMethods implements Function<String, IntStream> {
          *
          * @param line the current text chunk
          * @return an int stream of counts
+         *
          * @since sprint 1
          */
         @Override
@@ -30,6 +31,13 @@ public enum CountingMethods implements Function<String, IntStream> {
 
     }, lines() {
 
+        /**
+         * Computes the line count by checking if the text is blank.
+         * @param line the current text chunk
+         * @return an int stream that contains zero if the chunk is blank or else 1
+         *
+         * @since sprint 1
+         */
         @Override
         public IntStream apply(String line) {
             return IntStream.of(line.isBlank() ? 0 : 1);

--- a/src/main/java/dev/grevend/count/CountingMethods.java
+++ b/src/main/java/dev/grevend/count/CountingMethods.java
@@ -18,7 +18,7 @@ public enum CountingMethods implements Function<String, IntStream> {
          */
         @Override
         public IntStream apply(String line) {
-            return humanReadable.matcher(line.strip()).results().map(MatchResult::group).mapToInt(String::length);
+            return humanReadable.matcher(line).results().map(MatchResult::group).mapToInt(String::length);
         }
 
     }, words() {
@@ -32,7 +32,7 @@ public enum CountingMethods implements Function<String, IntStream> {
 
         @Override
         public IntStream apply(String line) {
-            return IntStream.empty();
+            return IntStream.of(line.isBlank() ? 0 : 1);
         }
 
     };

--- a/src/test/java/dev/grevend/count/CountTest.java
+++ b/src/test/java/dev/grevend/count/CountTest.java
@@ -2,9 +2,14 @@ package dev.grevend.count;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.params.provider.Arguments.of;
 
 public class CountTest {
 
@@ -30,6 +35,24 @@ public class CountTest {
     @ParameterizedTest
     public void testHumanReadableCount(String input, String count) {
         var commandLine = new TestCommandLine(new String[]{}, new String[]{input});
+        assertThat(commandLine.execute()).isZero();
+        assertThat(commandLine.out().toString()).startsWith(count);
+    }
+
+    private static Stream<Arguments> testLines() {
+        return Stream.of(
+            of(new String[]{}, "0"),
+            of(new String[]{""}, "0"),
+            of(new String[]{" "}, "0"),
+            of(new String[]{"first"}, "1"),
+            of(new String[]{"first", "second"}, "2")
+        );
+    }
+
+    @MethodSource(value = "testLines")
+    @ParameterizedTest
+    public void testLineCount(String[] input, String count) {
+        var commandLine = new TestCommandLine(new String[]{"-m", "lines"}, input);
         assertThat(commandLine.execute()).isZero();
         assertThat(commandLine.out().toString()).startsWith(count);
     }


### PR DESCRIPTION
# Description

Allow the line count to be used instead of the number of human-readable characters.

## Checklist

### Management

- [x] Link Issue
- [x] Add Description
- [x] Assign Sprint
- [x] Assign Moscow Prioritization

### Testing

- [x] Functionality
- [x] Coverage >= 80%

### Implementation

- [x] Documentation
- [x] Possible Optimizations
- [x] Convention Usage

### Review

- [x] Complexity & Readability
- [x] Convention Usage
- [x] Formatting
- [x] Possible Optimizations
