### PR TITLE
Add output destination option

### DIFF
--- a/src/main/java/dev/grevend/count/Count.java
+++ b/src/main/java/dev/grevend/count/Count.java
@@ -65,13 +65,17 @@ public class Count implements Callable<Integer> {
     /**
      * Returns or constructs an input stream based on the selected command options.
      *
-     * @return the input stream
+     * @return the input stream or null if the input file is a directory
      *
      * @throws FileNotFoundException if the input file is not found
      * @since sprint 1
      */
     protected BufferedReader in() throws FileNotFoundException {
-        return new BufferedReader(new InputStreamReader(inputFile != null && inputFile.isFile() ? new FileInputStream(inputFile) : System.in));
+        if(inputFile != null && inputFile.isDirectory()) {
+            spec.commandLine().getErr().println("Input file is a directory!");
+            return null;
+        }
+        return new BufferedReader(new InputStreamReader(inputFile != null ? new FileInputStream(inputFile) : System.in));
     }
 
     /**
@@ -83,7 +87,15 @@ public class Count implements Callable<Integer> {
      * @since sprint 1
      */
     private PrintWriter out() throws IOException {
-        if(outputFile != null && outputFile.isFile() && !outputFile.exists()) outputFile.createNewFile();
+        if(outputFile != null && !outputFile.exists()) {
+            if(outputFile.isFile()) {
+                //noinspection ResultOfMethodCallIgnored
+                outputFile.createNewFile();
+            } else {
+                spec.commandLine().getErr().println("Output file is a directory!");
+                return spec.commandLine().getOut();
+            }
+        }
         return outputFile == null ? spec.commandLine().getOut() : new PrintWriter(outputFile);
     }
 

--- a/src/main/java/dev/grevend/count/Count.java
+++ b/src/main/java/dev/grevend/count/Count.java
@@ -25,8 +25,11 @@ public class Count implements Callable<Integer> {
     @Spec
     private CommandSpec spec;
 
-    @Parameters(index = "0", description = "Input file", arity = "0..1")
+    @Parameters(index = "0", description = "Input file (default: read from console)", arity = "0..1")
     private File inputFile;
+
+    @Option(names = {"-o", "--out"}, description = "Output file (default: print to console)", arity = "0..1")
+    private File outputFile;
 
     @Option(names = {"-m", "--method"}, description = "Counting method (default: chars)", arity = "0..1",
         defaultValue = "chars", showDefaultValue = CommandLine.Help.Visibility.NEVER)
@@ -76,10 +79,12 @@ public class Count implements Callable<Integer> {
      *
      * @return the output stream
      *
+     * @throws java.io.IOException if the output file creation fails
      * @since sprint 1
      */
-    private PrintWriter out() {
-        return spec.commandLine().getOut();
+    private PrintWriter out() throws IOException {
+        if(outputFile != null && !outputFile.exists()) outputFile.createNewFile();
+        return outputFile == null ? spec.commandLine().getOut() : new PrintWriter(outputFile);
     }
 
 }

--- a/src/main/java/dev/grevend/count/Count.java
+++ b/src/main/java/dev/grevend/count/Count.java
@@ -71,7 +71,7 @@ public class Count implements Callable<Integer> {
      * @since sprint 1
      */
     protected BufferedReader in() throws FileNotFoundException {
-        if(inputFile != null && inputFile.isDirectory()) {
+        if(inputFile != null && !inputFile.isFile()) {
             spec.commandLine().getErr().println("Input file is a directory!");
             return null;
         }
@@ -87,14 +87,9 @@ public class Count implements Callable<Integer> {
      * @since sprint 1
      */
     private PrintWriter out() throws IOException {
-        if(outputFile != null && !outputFile.exists()) {
-            if(!outputFile.isDirectory()) {
-                //noinspection ResultOfMethodCallIgnored
-                outputFile.createNewFile();
-            } else {
-                spec.commandLine().getErr().println("Output file is a directory!");
-                return spec.commandLine().getOut();
-            }
+        if(outputFile != null && !outputFile.exists() && !outputFile.isDirectory()) {
+            //noinspection ResultOfMethodCallIgnored
+            outputFile.createNewFile();
         }
         return outputFile == null ? spec.commandLine().getOut() : new PrintWriter(outputFile);
     }

--- a/src/main/java/dev/grevend/count/Count.java
+++ b/src/main/java/dev/grevend/count/Count.java
@@ -71,7 +71,7 @@ public class Count implements Callable<Integer> {
      * @since sprint 1
      */
     protected BufferedReader in() throws FileNotFoundException {
-        return new BufferedReader(new InputStreamReader(inputFile == null ? System.in : new FileInputStream(inputFile)));
+        return new BufferedReader(new InputStreamReader(inputFile != null && inputFile.isFile() ? new FileInputStream(inputFile) : System.in));
     }
 
     /**
@@ -83,7 +83,7 @@ public class Count implements Callable<Integer> {
      * @since sprint 1
      */
     private PrintWriter out() throws IOException {
-        if(outputFile != null && !outputFile.exists()) outputFile.createNewFile();
+        if(outputFile != null && outputFile.isFile() && !outputFile.exists()) outputFile.createNewFile();
         return outputFile == null ? spec.commandLine().getOut() : new PrintWriter(outputFile);
     }
 

--- a/src/main/java/dev/grevend/count/Count.java
+++ b/src/main/java/dev/grevend/count/Count.java
@@ -88,7 +88,7 @@ public class Count implements Callable<Integer> {
      */
     private PrintWriter out() throws IOException {
         if(outputFile != null && !outputFile.exists()) {
-            if(outputFile.isFile()) {
+            if(!outputFile.isDirectory()) {
                 //noinspection ResultOfMethodCallIgnored
                 outputFile.createNewFile();
             } else {

--- a/src/main/java/dev/grevend/count/Utils.java
+++ b/src/main/java/dev/grevend/count/Utils.java
@@ -27,7 +27,7 @@ public final class Utils {
      * @since sprint 1
      */
     public static Stream<String> lines(BufferedReader reader) {
-        return StreamSupport.stream(Spliterators.spliteratorUnknownSize(new Iterator<>() {
+        return reader != null ? StreamSupport.stream(Spliterators.spliteratorUnknownSize(new Iterator<>() {
             private String nextLine = null;
 
             @Override
@@ -49,7 +49,7 @@ public final class Utils {
                     throw new NoSuchElementException();
                 }
             }
-        }, Spliterator.ORDERED | Spliterator.NONNULL), false);
+        }, Spliterator.ORDERED | Spliterator.NONNULL), false) : Stream.empty();
     }
 
 }

--- a/src/test/java/dev/grevend/count/CountTest.java
+++ b/src/test/java/dev/grevend/count/CountTest.java
@@ -7,6 +7,10 @@ import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.stream.Stream;
 
 import static dev.grevend.count.CountingMethods.*;
@@ -59,6 +63,16 @@ public class CountTest {
         assertThat(commandLine.out().toString().strip()).endsWith("16");
     }
 
+    @Test
+    public void testHumanReadableCountToOutputFile() throws IOException {
+        var path = Path.of("src/test/resources/test-output.txt");
+        var commandLine = new TestCommandLine(new String[]{"-o", path.toString(), "-m", "chars"},
+            new String[]{"Hello World", "& count"});
+        assertThat(commandLine.execute()).isZero();
+        assertThat(Files.lines(path).findFirst()).hasValue("16");
+        Files.deleteIfExists(path);
+    }
+
     private static Stream<Arguments> testLines() {
         return Stream.of(
             of(new String[]{}, "0"),
@@ -84,6 +98,16 @@ public class CountTest {
         var commandLine = new TestCommandLine("src/test/resources/test-input.txt", "-m", "lines");
         assertThat(commandLine.execute()).isZero();
         assertThat(commandLine.out().toString().strip()).endsWith("2");
+    }
+
+    @Test
+    public void testLineCountToOutputFile() throws IOException {
+        var path = Path.of("src/test/resources/test-output.txt");
+        var commandLine = new TestCommandLine(new String[]{"-o", path.toString(), "-m", "lines"},
+            new String[]{"Hello World", "& count"});
+        assertThat(commandLine.execute()).isZero();
+        assertThat(Files.lines(path).findFirst()).hasValue("2");
+        Files.deleteIfExists(path);
     }
 
     @CsvSource({
@@ -119,6 +143,16 @@ public class CountTest {
         var commandLine = new TestCommandLine("src/test/resources/test-input.txt", "-m", "words");
         assertThat(commandLine.execute()).isZero();
         assertThat(commandLine.out().toString().strip()).endsWith("3");
+    }
+
+    @Test
+    public void testWordCountToOutputFile() throws IOException {
+        var path = Path.of("src/test/resources/test-output.txt");
+        var commandLine = new TestCommandLine(new String[]{"-o", path.toString(), "-m", "words"},
+            new String[]{"Hello World", "& count"});
+        assertThat(commandLine.execute()).isZero();
+        assertThat(Files.lines(path).findFirst()).hasValue("3");
+        Files.deleteIfExists(path);
     }
 
 }

--- a/src/test/java/dev/grevend/count/CountTest.java
+++ b/src/test/java/dev/grevend/count/CountTest.java
@@ -10,7 +10,6 @@ import org.junit.jupiter.params.provider.ValueSource;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.stream.Stream;
 
 import static dev.grevend.count.CountingMethods.*;
@@ -26,6 +25,14 @@ public class CountTest {
         assertThat(commandLine.execute()).isZero();
         assertThat(commandLine.out().toString()).contains("Count the human-readable characters, lines, or" +
             " words from stdin or a file and" + System.lineSeparator() + "write the number to stdout or a file.");
+    }
+
+    @Test
+    public void testDirectoryAsInputFile() {
+        var commandLine = new TestCommandLine("src/test/resources/test-input/");
+        assertThat(commandLine.execute()).isZero();
+        assertThat(commandLine.out().toString().strip()).endsWith("0");
+        assertThat(commandLine.err().toString()).startsWith("Input file is a directory!");
     }
 
     @CsvSource({

--- a/src/test/java/dev/grevend/count/TestCommandLine.java
+++ b/src/test/java/dev/grevend/count/TestCommandLine.java
@@ -19,7 +19,7 @@ public final class TestCommandLine {
 
     private final String[] args;
     private final CommandLine commandLine;
-    private final StringWriter out;
+    private final StringWriter out, err;
 
     /**
      * Constructs a test CommandLine with the provided args.
@@ -32,7 +32,9 @@ public final class TestCommandLine {
         this.args = args;
         this.commandLine = new CommandLine(new Count());
         this.out = new StringWriter();
+        this.err = new StringWriter();
         this.commandLine.setOut(new PrintWriter(this.out));
+        this.commandLine.setErr(new PrintWriter(this.err));
     }
 
     /**
@@ -56,7 +58,9 @@ public final class TestCommandLine {
         }
         this.commandLine = new CommandLine(countSpy);
         this.out = new StringWriter();
+        this.err = new StringWriter();
         this.commandLine.setOut(new PrintWriter(this.out));
+        this.commandLine.setErr(new PrintWriter(this.err));
     }
 
     /**
@@ -79,6 +83,17 @@ public final class TestCommandLine {
      */
     public StringWriter out() {
         return out;
+    }
+
+    /**
+     * Returns the constructed StringWriter representing the test error stream.
+     *
+     * @return the error stream as a StringWriter
+     *
+     * @since sprint 1
+     */
+    public StringWriter err() {
+        return err;
     }
 
     /**

--- a/src/test/java/dev/grevend/count/UtilsTest.java
+++ b/src/test/java/dev/grevend/count/UtilsTest.java
@@ -16,6 +16,11 @@ import static org.mockito.Mockito.when;
 public class UtilsTest {
 
     @Test
+    public void testLinesNullReader() {
+        assertThat(Utils.lines(null).count()).isZero();
+    }
+
+    @Test
     public void testLinesHasNext() throws IOException {
         var reader = mock(BufferedReader.class);
         var values = List.of("first", "second").iterator();


### PR DESCRIPTION
# Description

Add an option that defines the destination (path to a file) that the command should write the output into instead of stdout.

## Checklist

### Management

- [x] Link Issue
- [x] Add Description
- [x] Assign Sprint
- [x] Assign Moscow Prioritization

### Testing

- [x] Functionality
- [x] Coverage >= 80%

### Implementation

- [x] Documentation
- [x] Possible Optimizations
- [x] Convention Usage

### Review

- [x] Complexity & Readability
- [x] Convention Usage
- [x] Formatting
- [x] Possible Optimizations
