### PR TITLE
Read-only output destination crashes CLI

### DIFF
--- a/src/main/java/dev/grevend/count/Utils.java
+++ b/src/main/java/dev/grevend/count/Utils.java
@@ -1,8 +1,7 @@
 package dev.grevend.count;
 
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.UncheckedIOException;
+import java.io.*;
+import java.nio.file.Files;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
 import java.util.Spliterator;
@@ -50,6 +49,56 @@ public final class Utils {
                 }
             }
         }, Spliterator.ORDERED | Spliterator.NONNULL), false) : Stream.empty();
+    }
+
+    /**
+     * Returns whether the given {@code File} exists.
+     *
+     * @param file the {@code File} to check
+     * @param err  the {@code PrintWriter} provided for error output
+     *
+     * @return if the {@code File} exists
+     *
+     * @since sprint 2
+     */
+    public static boolean exists(File file, PrintWriter err) {
+        var does = file != null && file.exists() && !file.isDirectory();
+        if (!does && file != null) {
+            if (file.isDirectory()) {
+                err.println("Output path points to a directory!");
+                return false;
+            } else {
+                try {
+                    if (!file.exists() && !file.createNewFile()) {
+                        throw new IOException();
+                    } else {
+                        return true;
+                    }
+                } catch (IOException | SecurityException e) {
+                    err.println("Failed to create output file!");
+                    return false;
+                }
+            }
+        }
+        return does;
+    }
+
+    /**
+     * Returns whether the given {@code File} is writable.
+     *
+     * @param file the {@code File} to check
+     * @param err  the {@code PrintWriter} provided for error output
+     *
+     * @return if the {@code File} is writable
+     *
+     * @since sprint 2
+     */
+    public static boolean writable(File file, PrintWriter err) {
+        var is = exists(file, err) && file != null && Files.isWritable(file.toPath());
+        if (!is && file != null && file.exists()) {
+            err.println("Output file is read-only!");
+        }
+        return is;
     }
 
 }

--- a/src/test/java/dev/grevend/count/UtilsTest.java
+++ b/src/test/java/dev/grevend/count/UtilsTest.java
@@ -2,16 +2,15 @@ package dev.grevend.count;
 
 import org.junit.jupiter.api.Test;
 
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.UncheckedIOException;
+import java.io.*;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.List;
 import java.util.NoSuchElementException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 public class UtilsTest {
 
@@ -70,6 +69,104 @@ public class UtilsTest {
         var iter = Utils.lines(reader).iterator();
         iter.next();
         assertThatThrownBy(iter::next).isExactlyInstanceOf(NoSuchElementException.class);
+    }
+
+    @Test
+    public void testExistsWithoutFile() {
+        assertThat(Utils.exists(null, null)).isFalse();
+    }
+
+    @Test
+    public void testExistsWithNonexistentFile() {
+        var writer = new StringWriter();
+        var file = mock(File.class);
+        when(file.exists()).thenReturn(false);
+        assertThat(Utils.exists(file, new PrintWriter(writer))).isFalse();
+        assertThat(writer.toString().strip()).isEqualTo("Failed to create output file!");
+    }
+
+    @Test
+    public void testExistsWithDirectory() {
+        var writer = new StringWriter();
+        var file = mock(File.class);
+        when(file.isDirectory()).thenReturn(true);
+        assertThat(Utils.exists(file, new PrintWriter(writer))).isFalse();
+        assertThat(writer.toString().strip()).isEqualTo("Output path points to a directory!");
+    }
+
+    @Test
+    public void testExistsFailureOnCreation() throws IOException {
+        var writer = new StringWriter();
+        var file = mock(File.class);
+        when(file.exists()).thenReturn(false);
+        when(file.createNewFile()).thenReturn(false);
+        assertThat(Utils.exists(file, new PrintWriter(writer))).isFalse();
+        assertThat(writer.toString().strip()).isEqualTo("Failed to create output file!");
+    }
+
+    @Test
+    public void testExistsSuccessOnCreation() throws IOException {
+        var writer = new StringWriter();
+        var file = mock(File.class);
+        when(file.exists()).thenReturn(false);
+        when(file.createNewFile()).thenReturn(true);
+        assertThat(Utils.exists(file, new PrintWriter(writer))).isTrue();
+        assertThat(writer.toString().strip()).isBlank();
+    }
+
+    @Test
+    public void testWritableWithoutFile() {
+        assertThat(Utils.writable(null, mock(PrintWriter.class))).isFalse();
+    }
+
+    @Test
+    public void testWritableWithNonexistentFile() {
+        var writer = new StringWriter();
+        var file = mock(File.class);
+        when(file.exists()).thenReturn(false);
+        assertThat(Utils.writable(file, new PrintWriter(writer))).isFalse();
+        assertThat(writer.toString().strip()).isEqualTo("Failed to create output file!");
+    }
+
+    @Test
+    public void testWritableWithDirectory() {
+        var writer = new StringWriter();
+        var file = mock(File.class);
+        when(file.isDirectory()).thenReturn(true);
+        assertThat(Utils.writable(file, new PrintWriter(writer))).isFalse();
+        assertThat(writer.toString().strip()).isEqualTo("Output path points to a directory!");
+    }
+
+    @Test
+    public void testWritableFailureOnCreation() throws IOException {
+        var writer = new StringWriter();
+        var file = mock(File.class);
+        when(file.exists()).thenReturn(false);
+        when(file.createNewFile()).thenReturn(false);
+        assertThat(Utils.writable(file, new PrintWriter(writer))).isFalse();
+        assertThat(writer.toString().strip()).isEqualTo("Failed to create output file!");
+    }
+
+    @Test
+    public void testWritableSuccessOnCreation() {
+        var writer = new StringWriter();
+        var file = new File("./test-writable.txt");
+        assertThat(Utils.writable(file, new PrintWriter(writer))).isTrue();
+        assertThat(writer.toString().strip()).isBlank();
+        assertThat(file.delete()).isTrue();
+        file.deleteOnExit();
+    }
+
+    @Test
+    public void testWritableReadOnlyFile() throws IOException {
+        var writer = new StringWriter();
+        var file = new File("./test-read-only.txt");
+        assertThat(file.createNewFile()).isTrue();
+        assertThat(file.setReadOnly()).isTrue();
+        assertThat(Utils.writable(file, new PrintWriter(writer))).isFalse();
+        assertThat(writer.toString().strip()).isEqualTo("Output file is read-only!");
+        assertThat(file.delete()).isTrue();
+        file.deleteOnExit();
     }
 
 }


### PR DESCRIPTION
# Description

Check whether the given output file is read-only and display an appropriate error message.

## Checklist

### Management

- [x] Link Issue
- [x] Add Description
- [x] Assign Sprint
- [x] Assign Moscow Prioritization

### Testing

- [x] Functionality
- [x] Coverage >= 80%

### Implementation

- [x] Documentation
- [x] Possible Optimizations
- [x] Convention Usage

### Review

- [x] Complexity & Readability
- [x] Convention Usage
- [x] Formatting
